### PR TITLE
chore: remove binary demo assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Lint
+        run: make lint
+      - name: Typecheck
+        run: make typecheck
+      - name: Tests
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.so
+.build/
+build/
+dist/
+html2manual.egg-info/
+.env
+.venv
+.pytest_cache/
+.mypy_cache/
+.nox/
+.pyinstaller/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wkhtmltopdf \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir .
+
+ENTRYPOINT ["html2manual"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: lint typecheck test all format
+
+lint:
+@ruff check .
+@black --check .
+
+format:
+@black .
+
+typecheck:
+@mypy .
+
+test:
+@pytest
+
+all: lint typecheck test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,107 @@
-# html_to_pdf
-html to pdf
+# html2manual
+
+html2manual converts a directory of HTML manuals into sectioned PDFs. It flattens
+each HTML page by inlining assets, applies overflow fixes, groups pages using a
+menu definition (with automatic fallbacks), and renders PDFs via wkhtmltopdf
+with an optional Playwright fallback.
+
+## Quickstart
+
+```bash
+pip install -e .[dev]
+html2manual init  # writes html2manual.yaml
+html2manual build --config html2manual.yaml
+```
+
+The repository ships with `examples/sample_manual` which demonstrates a simple
+menu-driven project.
+
+## Prerequisites
+
+- Python 3.11
+- [wkhtmltopdf](https://wkhtmltopdf.org/) available on your PATH (or provide
+  `wkhtmltopdf_path` in the config)
+- Optional fallback: Playwright (`pip install playwright` and run
+  `playwright install chromium`)
+
+## Commands
+
+- `html2manual init` – create a sample configuration file.
+- `html2manual flatten` – flatten HTML files into `output_dir/flattened`.
+- `html2manual render` – render pre-flattened HTML to PDFs.
+- `html2manual build` – full pipeline (parse → flatten → render).
+- `html2manual audit` – detect scrollable containers and overflow issues.
+
+## Configuration
+
+Configuration is provided via `html2manual.yaml` or CLI overrides. Key options:
+
+- `input_dir`, `output_dir`
+- `menu_file`, `contents_glob`
+- Rendering options: `page_size`, `margin_*`, `zoom`
+- Inlining toggles: `css_inline`, `js_inline`, `images_inline`
+- Overflow control: `overflow_fix_enable`, `overflow_fix_selectors`
+- Renderer fallback: `playwright_fallback`
+- `chunk_size` to avoid Windows command line limits
+- Menu fallback selection via `fallback_strategy`
+
+## Examples
+
+### With a menu
+
+The sample project contains `menu.html` that defines sections using
+`display('file','title','/SECTION/...')`. The parser groups the referenced files
+into the corresponding sections.
+
+### Without a menu
+
+When `menu.html` is absent the fallback strategy groups files by filename prefix
+(e.g. `chapter1_intro.html`, `chapter1_overview.html`). This behaviour can be
+configured through the `fallback_strategy` configuration key (`single`, `prefix`,
+or `subfolder`).
+
+## Troubleshooting
+
+- **Blank pages** – ensure CSS/JS resources resolve correctly. The flattening
+  stage reports missing assets via warnings in structured logs.
+- **Scrollbars in output** – run `html2manual audit` to discover problematic
+  containers and adjust the `overflow_fix_selectors` configuration.
+- **Missing images** – verify paths in the source HTML. The inliner attempts to
+  resolve relative paths from each HTML file's directory and `html2manual audit`
+  reports unresolved assets.
+- **PDF merge issues** – chunked rendering merges using `pypdf`. Confirm the
+  intermediate chunk PDFs are produced and not corrupt.
+
+## Sample Configuration
+
+```yaml
+input_dir: examples/sample_manual
+output_dir: build
+menu_file: menu.html
+contents_glob: Contents/**/*.html
+page_size: A4
+margin_top: 10mm
+margin_bottom: 10mm
+margin_left: 10mm
+margin_right: 10mm
+zoom: 1.0
+overflow_fix_enable: true
+overflow_fix_selectors:
+  - .container
+images_inline: true
+css_inline: true
+js_inline: true
+playwright_fallback: true
+chunk_size: 25
+fallback_strategy: prefix
+```
+
+## Development
+
+- `make lint` – run linters (ruff + black).
+- `make typecheck` – run mypy.
+- `make test` – run pytest.
+- `make all` – run the full suite.
+
+The project also provides a Nox configuration and CI workflow that run the same
+checks.

--- a/examples/sample_manual/Contents/intro.html
+++ b/examples/sample_manual/Contents/intro.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Intro</title>
+  <link rel="stylesheet" href="../assets/style.css">
+</head>
+<body>
+  <div class="container" style="overflow:auto;height:200px;">
+    <h1>Introduction</h1>
+    <p>Welcome to the sample manual.</p>
+  </div>
+  <script src="../assets/app.js"></script>
+</body>
+</html>

--- a/examples/sample_manual/Contents/setup.html
+++ b/examples/sample_manual/Contents/setup.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Setup</title>
+  <link rel="stylesheet" href="../assets/style.css">
+  <style>
+    .scroll-area { overflow: scroll; height: 150px; }
+  </style>
+</head>
+<body>
+  <div class="scroll-area">
+    <p>Setup instructions go here.</p>
+  </div>
+</body>
+</html>

--- a/examples/sample_manual/assets/app.js
+++ b/examples/sample_manual/assets/app.js
@@ -1,0 +1,1 @@
+console.log('Sample manual loaded');

--- a/examples/sample_manual/assets/style.css
+++ b/examples/sample_manual/assets/style.css
@@ -1,0 +1,6 @@
+.container {
+  font-family: Arial, sans-serif;
+  background: linear-gradient(135deg, #f0f4ff, #d9e4ff);
+  padding: 1rem;
+  border-radius: 8px;
+}

--- a/examples/sample_manual/menu.html
+++ b/examples/sample_manual/menu.html
@@ -1,0 +1,6 @@
+<script>
+function buildMenu() {
+  display('Contents/intro.html','Introduction','/SECTION1/Intro');
+  display('Contents/setup.html','Setup','/SECTION1/Setup');
+}
+</script>

--- a/html2manual.spec
+++ b/html2manual.spec
@@ -1,0 +1,43 @@
+# PyInstaller spec file for html2manual
+# To build: pyinstaller html2manual.spec
+
+block_cipher = None
+
+a = Analysis(
+    ['-m', 'html2manual.cli'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='html2manual',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='html2manual',
+)

--- a/html2manual.yaml
+++ b/html2manual.yaml
@@ -1,0 +1,19 @@
+input_dir: examples/sample_manual
+output_dir: build
+menu_file: menu.html
+contents_glob: Contents/**/*.html
+page_size: A4
+margin_top: 10mm
+margin_bottom: 10mm
+margin_left: 10mm
+margin_right: 10mm
+zoom: 1.0
+overflow_fix_enable: true
+overflow_fix_selectors:
+  - .container
+images_inline: true
+css_inline: true
+js_inline: true
+playwright_fallback: true
+chunk_size: 25
+fallback_strategy: prefix

--- a/html2manual/README.md
+++ b/html2manual/README.md
@@ -1,0 +1,8 @@
+# html2manual Package
+
+This package contains the implementation of the html2manual tool. Key subpackages:
+
+- `menu_parser` – strategies for mapping HTML files to manual sections.
+- `flatten` – routines to inline assets and normalise HTML.
+- `render` – PDF rendering backends and helpers.
+- `pipeline.py` – orchestration utilities used by the CLI.

--- a/html2manual/__init__.py
+++ b/html2manual/__init__.py
@@ -1,0 +1,10 @@
+"""Top level package for html2manual."""
+
+from .config import Html2ManualConfig, load_config
+from .pipeline import build_manuals
+
+__all__ = [
+    "Html2ManualConfig",
+    "load_config",
+    "build_manuals",
+]

--- a/html2manual/audit.py
+++ b/html2manual/audit.py
@@ -1,0 +1,115 @@
+"""Manual content auditing utilities."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from bs4 import BeautifulSoup
+
+from .flatten.encoding import read_text
+
+SCROLL_PATTERN = re.compile(r"overflow(?:-[xy])?\s*:\s*(auto|scroll)", re.IGNORECASE)
+EXTERNAL_PROTOCOLS = ("http://", "https://", "mailto:", "tel:")
+
+
+@dataclass(slots=True)
+class AuditIssue:
+    """Represents a potential problem discovered during an audit."""
+
+    file: Path
+    issue: str
+    suggestion: str
+
+
+def _is_external(reference: str) -> bool:
+    return reference.startswith(EXTERNAL_PROTOCOLS) or reference.startswith("#") or reference.startswith("data:")
+
+
+def _resolve_reference(html_path: Path, reference: str) -> Path:
+    return (html_path.parent / reference).resolve()
+
+
+def audit_html(path: Path) -> List[AuditIssue]:
+    """Audit a single HTML file for scrollable containers and missing assets."""
+
+    html = read_text(path)
+    soup = BeautifulSoup(html, "html.parser")
+    issues: List[AuditIssue] = []
+
+    for element in soup.find_all(style=True):
+        style_attr = element.get("style")
+        if isinstance(style_attr, list):
+            style_attr = " ".join(style_attr)
+        if isinstance(style_attr, str) and SCROLL_PATTERN.search(style_attr):
+            issues.append(
+                AuditIssue(
+                    file=path,
+                    issue="Scrollable container detected",
+                    suggestion="Enable overflow_fix or adjust CSS to use height:auto and overflow:visible.",
+                )
+            )
+
+    for style_tag in soup.find_all("style"):
+        content = style_tag.string
+        if content and SCROLL_PATTERN.search(str(content)):
+            issues.append(
+                AuditIssue(
+                    file=path,
+                    issue="Stylesheet defines overflow:auto/scroll",
+                    suggestion="Update stylesheet or include selector in overflow_fix_selectors.",
+                )
+            )
+
+    for tag_name, attribute in ("img", "src"), ("script", "src"), ("link", "href"):
+        for tag in soup.find_all(tag_name):
+            value = tag.get(attribute)
+            if isinstance(value, list):
+                value = value[0] if value else None
+            if not isinstance(value, str) or not value or _is_external(value):
+                continue
+            if tag_name == "link":
+                rel = tag.get("rel")
+                rel_values = {entry.lower() for entry in rel} if isinstance(rel, list) else {str(rel).lower()} if rel else set()
+                if rel_values and "stylesheet" not in rel_values:
+                    continue
+            asset_path = _resolve_reference(path, value)
+            if not asset_path.exists():
+                issues.append(
+                    AuditIssue(
+                        file=path,
+                        issue=f"Missing asset: {value}",
+                        suggestion="Ensure the file exists relative to the HTML document or adjust the reference.",
+                    )
+                )
+
+    for anchor in soup.find_all("a", href=True):
+        href = anchor.get("href")
+        if isinstance(href, list):
+            href = href[0] if href else None
+        if not isinstance(href, str) or not href or _is_external(href):
+            continue
+        target = _resolve_reference(path, href)
+        if target.suffix.lower() in {".html", ".htm"} and not target.exists():
+            issues.append(
+                AuditIssue(
+                    file=path,
+                    issue=f"Broken link: {href}",
+                    suggestion="Update the anchor href to a valid document or remove the link.",
+                )
+            )
+
+    return issues
+
+
+def audit_manual(input_dir: Path, pattern: str) -> List[AuditIssue]:
+    """Audit all HTML files matching ``pattern`` relative to ``input_dir``."""
+
+    issues: List[AuditIssue] = []
+    for html_file in sorted(input_dir.glob(pattern)):
+        issues.extend(audit_html(html_file))
+    return issues
+
+
+__all__ = ["AuditIssue", "audit_html", "audit_manual"]

--- a/html2manual/cli.py
+++ b/html2manual/cli.py
@@ -1,0 +1,143 @@
+"""Command line interface for html2manual."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from .audit import AuditIssue, audit_manual
+from .config import Html2ManualConfig, load_config
+from .logging_setup import configure_logging
+from .pipeline import build_manuals, flatten_sections, parse_sections, render_sections
+
+app = typer.Typer(help="Generate manuals from HTML content.")
+console = Console()
+
+SAMPLE_CONFIG = """# html2manual configuration
+input_dir: examples/sample_manual
+output_dir: build
+menu_file: menu.html
+contents_glob: Contents/**/*.html
+page_size: A4
+margin_top: 10mm
+margin_bottom: 10mm
+margin_left: 10mm
+margin_right: 10mm
+zoom: 1.0
+overflow_fix_enable: true
+overflow_fix_selectors:
+  - .container
+images_inline: true
+css_inline: true
+js_inline: true
+playwright_fallback: true
+chunk_size: 25
+fallback_strategy: prefix
+"""
+
+
+def _load_runtime_config(
+    config_path: Optional[Path],
+    input_dir: Optional[Path],
+    output_dir: Optional[Path],
+    verbose: bool,
+) -> Html2ManualConfig:
+    overrides: Dict[str, Path | str] = {}
+    if input_dir:
+        overrides["input_dir"] = input_dir
+    if output_dir:
+        overrides["output_dir"] = output_dir
+    config = load_config(config_path, overrides)
+    log_level = "DEBUG" if verbose or config.verbose else "INFO"
+    configure_logging(log_level)
+    return config
+
+
+@app.command()
+def init(config_path: Path = typer.Option(Path("html2manual.yaml"), help="Path to write configuration.")) -> None:
+    """Write a sample configuration file."""
+
+    if config_path.exists():
+        typer.echo(f"Config file {config_path} already exists.")
+        raise typer.Exit(code=1)
+    config_path.write_text(SAMPLE_CONFIG, encoding="utf-8")
+    typer.echo(f"Sample configuration written to {config_path}")
+
+
+@app.command()
+def flatten(
+    config: Optional[Path] = typer.Option(None, help="Path to configuration file."),
+    input_dir: Optional[Path] = typer.Option(None, help="Override input directory."),
+    output_dir: Optional[Path] = typer.Option(None, help="Override output directory."),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging."),
+) -> None:
+    cfg = _load_runtime_config(config, input_dir, output_dir, verbose)
+    sections = parse_sections(cfg)
+    flattened = flatten_sections(cfg, sections)
+    typer.echo(f"Flattened {sum(len(v) for v in flattened.values())} files into {cfg.output_dir / 'flattened'}")
+
+
+@app.command()
+def render(
+    config: Optional[Path] = typer.Option(None, help="Path to configuration file."),
+    input_dir: Optional[Path] = typer.Option(None, help="Override input directory."),
+    output_dir: Optional[Path] = typer.Option(None, help="Override output directory."),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging."),
+) -> None:
+    cfg = _load_runtime_config(config, input_dir, output_dir, verbose)
+    flattened_root = cfg.output_dir / "flattened"
+    if not flattened_root.exists():
+        typer.echo("Flattened directory not found. Run 'html2manual flatten' first.")
+        raise typer.Exit(code=1)
+    flattened: Dict[str, List[Path]] = {}
+    for section_dir in flattened_root.iterdir():
+        if section_dir.is_dir():
+            flattened[section_dir.name] = sorted(section_dir.glob("*.html"))
+    manuals = render_sections(cfg, flattened)
+    typer.echo(f"Rendered {len(manuals)} manuals to {cfg.output_dir / 'Manuals'}")
+
+
+@app.command()
+def build(
+    config: Optional[Path] = typer.Option(None, help="Path to configuration file."),
+    input_dir: Optional[Path] = typer.Option(None, help="Override input directory."),
+    output_dir: Optional[Path] = typer.Option(None, help="Override output directory."),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging."),
+) -> None:
+    cfg = _load_runtime_config(config, input_dir, output_dir, verbose)
+    manuals = build_manuals(cfg)
+    typer.echo(json.dumps({k: str(v) for k, v in manuals.items()}, indent=2))
+
+
+@app.command()
+def audit(
+    config: Optional[Path] = typer.Option(None, help="Path to configuration file."),
+    input_dir: Optional[Path] = typer.Option(None, help="Override input directory."),
+    output_dir: Optional[Path] = typer.Option(None, help="Override output directory."),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging."),
+) -> None:
+    cfg = _load_runtime_config(config, input_dir, output_dir, verbose)
+    issues: List[AuditIssue] = audit_manual(cfg.input_dir, cfg.contents_glob)
+    if not issues:
+        console.print("[green]No audit issues detected.[/green]")
+        return
+
+    table = Table(title="Audit Issues")
+    table.add_column("File", style="cyan")
+    table.add_column("Issue", style="magenta")
+    table.add_column("Suggestion", style="green")
+
+    for issue in issues:
+        relative = issue.file.relative_to(cfg.input_dir) if issue.file.is_relative_to(cfg.input_dir) else issue.file
+        table.add_row(str(relative), issue.issue, issue.suggestion)
+
+    console.print(table)
+    console.print(f"[yellow]{len(issues)} issue(s) detected across {len({i.file for i in issues})} file(s).[/yellow]")
+
+
+if __name__ == "__main__":
+    app()

--- a/html2manual/config.py
+++ b/html2manual/config.py
@@ -1,0 +1,100 @@
+"""Configuration models and helpers for :mod:`html2manual`."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+from pydantic import BaseModel, Field, ConfigDict, field_validator
+
+DEFAULT_CONFIG_FILE = Path("html2manual.yaml")
+
+
+class Html2ManualConfig(BaseModel):
+    """Pydantic model describing configuration for html2manual."""
+
+    input_dir: Path = Field(..., description="Directory containing the HTML manual content.")
+    output_dir: Path = Field(..., description="Directory to place generated artifacts.")
+    menu_file: str = Field("menu.html", description="Menu file used to infer sections.")
+    contents_glob: str = Field(
+        "Contents/**/*.html", description="Glob pattern for discovering HTML content when no menu is present."
+    )
+    fallback_strategy: str = Field(
+        "prefix",
+        description="Fallback grouping strategy when no menu parser succeeds (single, prefix, or subfolder).",
+    )
+    wkhtmltopdf_path: Optional[Path] = Field(
+        None, description="Optional path to wkhtmltopdf binary; falls back to PATH if not provided."
+    )
+    page_size: str = Field("A4", description="Page size passed to the renderer.")
+    margin_top: str = Field("10mm", description="Top margin for PDFs.")
+    margin_bottom: str = Field("10mm", description="Bottom margin for PDFs.")
+    margin_left: str = Field("10mm", description="Left margin for PDFs.")
+    margin_right: str = Field("10mm", description="Right margin for PDFs.")
+    zoom: float = Field(1.0, description="Zoom level for wkhtmltopdf or Playwright rendering.")
+    overflow_fix_enable: bool = Field(True, description="Enable removing overflow scroll containers during flattening.")
+    overflow_fix_selectors: List[str] = Field(
+        default_factory=lambda: [".container"],
+        description="CSS selectors targeted when removing overflow styles.",
+    )
+    images_inline: bool = Field(True, description="Inline image assets via base64 data URIs.")
+    css_inline: bool = Field(True, description="Inline external CSS stylesheets.")
+    js_inline: bool = Field(True, description="Inline external JavaScript files.")
+    playwright_fallback: bool = Field(
+        True, description="Enable Playwright rendering fallback when wkhtmltopdf is unavailable or fails."
+    )
+    chunk_size: int = Field(
+        50,
+        description="Maximum number of HTML files to render per chunk when invoking wkhtmltopdf on Windows to avoid argument limits.",
+    )
+    verbose: bool = Field(False, description="Enable verbose (debug) logging output.")
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, validate_assignment=True)
+
+    @field_validator("input_dir", "output_dir", mode="before")
+    @classmethod
+    def _expand_paths(cls, value: Any) -> Path:
+        if isinstance(value, Path):
+            return value
+        return Path(value).expanduser().resolve()
+
+    @field_validator("fallback_strategy")
+    @classmethod
+    def _validate_strategy(cls, value: str) -> str:
+        allowed = {"single", "prefix", "subfolder"}
+        if value not in allowed:
+            raise ValueError(f"fallback_strategy must be one of {sorted(allowed)}")
+        return value
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Configuration file {path} must contain a mapping at the top level.")
+    return data
+
+
+def load_config(config_path: Optional[Path] = None, overrides: Optional[Dict[str, Any]] = None) -> Html2ManualConfig:
+    """Load configuration from YAML and optional overrides."""
+
+    path = (config_path or DEFAULT_CONFIG_FILE).expanduser().resolve()
+    data: Dict[str, Any] = {}
+    data.update(_load_yaml(path))
+
+    overrides = overrides or {}
+    # Flatten dotted overrides into nested dicts for convenience.
+    for key, value in overrides.items():
+        if value is None:
+            continue
+        data[key] = value
+
+    if "input_dir" not in data or "output_dir" not in data:
+        raise ValueError("Configuration must define both 'input_dir' and 'output_dir'.")
+
+    return Html2ManualConfig(**data)
+
+
+__all__ = ["Html2ManualConfig", "load_config", "DEFAULT_CONFIG_FILE"]

--- a/html2manual/flatten/README.md
+++ b/html2manual/flatten/README.md
@@ -1,0 +1,5 @@
+# Flatten Subpackage
+
+The flatten subpackage contains utilities that normalise HTML documents by
+inlining external CSS/JS assets, embedding images, fixing overflow styles and
+performing encoding detection.

--- a/html2manual/flatten/__init__.py
+++ b/html2manual/flatten/__init__.py
@@ -1,0 +1,5 @@
+"""HTML flattening utilities."""
+
+from .html_processor import HtmlProcessor
+
+__all__ = ["HtmlProcessor"]

--- a/html2manual/flatten/css_inliner.py
+++ b/html2manual/flatten/css_inliner.py
@@ -1,0 +1,90 @@
+"""CSS inlining helpers."""
+from __future__ import annotations
+
+import base64
+import mimetypes
+import re
+from pathlib import Path
+from typing import Optional
+
+from bs4 import BeautifulSoup
+
+from .encoding import read_text
+
+URL_PATTERN = re.compile(r"url\((?P<quote>['\"]?)(?!data:)(?P<path>[^)\"']+)(?P=quote)\)")
+
+
+def _as_string(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        for entry in value:
+            if entry:
+                return str(entry)
+        return None
+    return str(value)
+
+
+def _encode_asset(path: Path) -> Optional[str]:
+    if not path.exists():
+        return None
+    mime, _ = mimetypes.guess_type(path)
+    if mime is None:
+        mime = "application/octet-stream"
+    data = path.read_bytes()
+    encoded = base64.b64encode(data).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
+
+
+def _resolve_asset(base_dir: Path, asset_ref: str) -> Optional[Path]:
+    if re.match(r"^[a-zA-Z]+://", asset_ref):
+        return None
+    candidate = Path(asset_ref)
+    if not candidate.is_absolute():
+        candidate = (base_dir / asset_ref).resolve()
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def embed_css_urls(css_text: str, base_dir: Path) -> str:
+    """Rewrite ``url(...)`` references to inline data URIs where possible."""
+
+    def repl(match: re.Match[str]) -> str:
+        asset_ref = match.group("path").strip()
+        asset_path = _resolve_asset(base_dir, asset_ref)
+        if not asset_path:
+            return match.group(0)
+        data_uri = _encode_asset(asset_path)
+        if not data_uri:
+            return match.group(0)
+        return f"url('{data_uri}')"
+
+    return URL_PATTERN.sub(repl, css_text)
+
+
+def inline_css(html: str, html_path: Path) -> str:
+    """Inline external stylesheet links into the HTML document."""
+
+    soup = BeautifulSoup(html, "html.parser")
+    for link in soup.find_all("link", rel=lambda value: value and "stylesheet" in value):
+        href = _as_string(link.get("href"))
+        if not href:
+            continue
+        asset_path = _resolve_asset(html_path.parent, href)
+        if not asset_path:
+            continue
+        css_text = read_text(asset_path)
+        css_text = embed_css_urls(css_text, asset_path.parent)
+        style_tag = soup.new_tag("style")
+        style_tag.string = css_text
+        link.replace_with(style_tag)
+
+    for style in soup.find_all("style"):
+        if style.string is not None:
+            style.string = embed_css_urls(str(style.string), html_path.parent)
+
+    return str(soup)
+
+
+__all__ = ["inline_css", "embed_css_urls"]

--- a/html2manual/flatten/encoding.py
+++ b/html2manual/flatten/encoding.py
@@ -1,0 +1,31 @@
+"""Robust HTML text decoding helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from charset_normalizer import from_path
+
+FALLBACK_ENCODINGS: Iterable[str] = ("utf-8", "cp932", "shift_jis", "euc_jp", "iso-8859-1")
+
+
+def read_text(path: Path) -> str:
+    """Read text from *path* trying multiple encodings."""
+
+    try:
+        detection = from_path(path)
+        best = detection.best()
+        if best:
+            return str(best)
+    except Exception:
+        pass
+
+    for encoding in FALLBACK_ENCODINGS:
+        try:
+            return path.read_text(encoding=encoding)
+        except UnicodeDecodeError:
+            continue
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+__all__ = ["read_text", "FALLBACK_ENCODINGS"]

--- a/html2manual/flatten/html_processor.py
+++ b/html2manual/flatten/html_processor.py
@@ -1,0 +1,58 @@
+"""High level HTML flattening orchestration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+from . import css_inliner, image_inliner, js_inliner
+from .encoding import read_text
+from .overflow_fix import apply_overflow_fix
+
+
+@dataclass
+class FlattenResult:
+    html: str
+    warnings: List[str]
+
+
+class HtmlProcessor:
+    """Run a configurable flattening pipeline on HTML files."""
+
+    def __init__(
+        self,
+        *,
+        css_inline: bool = True,
+        js_inline: bool = True,
+        images_inline: bool = True,
+        overflow_fix_enable: bool = True,
+        overflow_selectors: Iterable[str] | None = None,
+    ) -> None:
+        self.css_inline = css_inline
+        self.js_inline = js_inline
+        self.images_inline = images_inline
+        self.overflow_fix_enable = overflow_fix_enable
+        self.overflow_selectors = list(overflow_selectors or [".container"])
+
+    def flatten(self, path: Path) -> FlattenResult:
+        html = read_text(path)
+        warnings: List[str] = []
+
+        if self.css_inline:
+            html = css_inliner.inline_css(html, path)
+        if self.js_inline:
+            html = js_inliner.inline_js(html, path)
+        if self.images_inline:
+            html = image_inliner.inline_images(html, path)
+        if self.overflow_fix_enable:
+            html = apply_overflow_fix(html, self.overflow_selectors)
+
+        return FlattenResult(html=html, warnings=warnings)
+
+    def flatten_to_file(self, path: Path, destination: Path) -> FlattenResult:
+        result = self.flatten(path)
+        destination.write_text(result.html, encoding="utf-8")
+        return result
+
+
+__all__ = ["HtmlProcessor", "FlattenResult"]

--- a/html2manual/flatten/image_inliner.py
+++ b/html2manual/flatten/image_inliner.py
@@ -1,0 +1,57 @@
+"""Image inlining utilities."""
+from __future__ import annotations
+
+import base64
+import mimetypes
+from pathlib import Path
+from typing import Optional
+
+from bs4 import BeautifulSoup
+
+from .css_inliner import embed_css_urls
+
+
+def _as_string(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        for entry in value:
+            if entry:
+                return str(entry)
+        return None
+    return str(value)
+
+
+def _encode_image(path: Path) -> Optional[str]:
+    if not path.exists():
+        return None
+    mime, _ = mimetypes.guess_type(path)
+    if mime is None:
+        mime = "application/octet-stream"
+    data = path.read_bytes()
+    encoded = base64.b64encode(data).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
+
+
+def inline_images(html: str, html_path: Path) -> str:
+    """Inline image tags and inline-style backgrounds."""
+
+    soup = BeautifulSoup(html, "html.parser")
+    for img in soup.find_all("img"):
+        src = _as_string(img.get("src"))
+        if not src or src.startswith("data:"):
+            continue
+        asset_path = (html_path.parent / src).resolve()
+        data_uri = _encode_image(asset_path)
+        if data_uri:
+            img["src"] = data_uri
+
+    for tag in soup.find_all(style=True):
+        style_value = _as_string(tag.get("style"))
+        if style_value:
+            tag["style"] = embed_css_urls(style_value, html_path.parent)
+
+    return str(soup)
+
+
+__all__ = ["inline_images"]

--- a/html2manual/flatten/js_inliner.py
+++ b/html2manual/flatten/js_inliner.py
@@ -1,0 +1,31 @@
+"""JavaScript inlining utilities."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+
+from .encoding import read_text
+
+
+def inline_js(html: str, html_path: Path) -> str:
+    """Inline external script tags."""
+
+    soup = BeautifulSoup(html, "html.parser")
+    for script in soup.find_all("script", src=True):
+        src_attr = script.get("src")
+        if isinstance(src_attr, list):
+            src_attr = src_attr[0] if src_attr else None
+        if not isinstance(src_attr, str) or not src_attr:
+            continue
+        asset_path = (html_path.parent / src_attr).resolve()
+        if not asset_path.exists():
+            continue
+        script_text = read_text(asset_path)
+        new_tag = soup.new_tag("script")
+        new_tag.string = script_text
+        script.replace_with(new_tag)
+    return str(soup)
+
+
+__all__ = ["inline_js"]

--- a/html2manual/flatten/overflow_fix.py
+++ b/html2manual/flatten/overflow_fix.py
@@ -1,0 +1,46 @@
+"""Remove scrollable containers and fixed heights."""
+from __future__ import annotations
+
+import re
+from typing import List
+
+from bs4 import BeautifulSoup
+
+INLINE_OVERFLOW_PATTERN = re.compile(r"overflow(-[xy])?\s*:\s*(auto|scroll)", re.IGNORECASE)
+HEIGHT_PATTERN = re.compile(r"height\s*:\s*\d+px", re.IGNORECASE)
+
+
+def _rewrite_inline_style(style_value: str) -> str:
+    updated = INLINE_OVERFLOW_PATTERN.sub(lambda m: f"overflow{m.group(1) or ''}: visible", style_value)
+    updated = HEIGHT_PATTERN.sub("height: auto", updated)
+    return updated
+
+
+def _rewrite_style_block(css_text: str, selectors: List[str]) -> str:
+    css_text = INLINE_OVERFLOW_PATTERN.sub(lambda m: f"overflow{m.group(1) or ''}: visible", css_text)
+    for selector in selectors:
+        pattern = re.compile(rf"({re.escape(selector)}[^{{]*{{[^}}]*?)height\s*:\s*\d+px", re.IGNORECASE | re.DOTALL)
+        css_text = pattern.sub(lambda m: m.group(1) + "height: auto", css_text)
+    return css_text
+
+
+def apply_overflow_fix(html: str, selectors: List[str]) -> str:
+    """Apply overflow fixes to inline and embedded styles."""
+
+    soup = BeautifulSoup(html, "html.parser")
+    for element in soup.find_all(style=True):
+        original = element.get("style")
+        if isinstance(original, list):
+            original = " ".join(original)
+        if not isinstance(original, str) or not original:
+            continue
+        element["style"] = _rewrite_inline_style(original)
+
+    for style in soup.find_all("style"):
+        if style.string is not None:
+            style.string = _rewrite_style_block(str(style.string), selectors)
+
+    return str(soup)
+
+
+__all__ = ["apply_overflow_fix"]

--- a/html2manual/logging_setup.py
+++ b/html2manual/logging_setup.py
@@ -1,0 +1,63 @@
+"""Structured logging helpers using structlog."""
+from __future__ import annotations
+
+from logging.config import dictConfig
+from pathlib import Path
+from typing import Optional
+
+import structlog
+
+
+def configure_logging(log_level: str = "INFO", log_file: Optional[Path] = None) -> None:
+    """Configure structlog with JSON output and optional file logging."""
+
+    shared_handlers = ["default"]
+    handler_defs = {
+        "default": {
+            "class": "logging.StreamHandler",
+            "formatter": "json",
+        }
+    }
+
+    if log_file:
+        handler_defs["file"] = {
+            "class": "logging.FileHandler",
+            "formatter": "json",
+            "filename": str(log_file),
+        }
+        shared_handlers.append("file")
+
+    dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "json": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processor": structlog.processors.JSONRenderer(),
+                }
+            },
+            "handlers": handler_defs,
+            "root": {
+                "level": log_level,
+                "handlers": shared_handlers,
+            },
+        }
+    )
+
+    structlog.configure(
+        processors=[
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+            structlog.processors.JSONRenderer(),
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+
+__all__ = ["configure_logging"]

--- a/html2manual/menu_parser/README.md
+++ b/html2manual/menu_parser/README.md
@@ -1,0 +1,5 @@
+# Menu Parser Subpackage
+
+Provides default menu parsing implementations and a plugin interface via entry
+points. Custom parsers can be registered under the `html2manual.menu_parsers`
+entry point group.

--- a/html2manual/menu_parser/__init__.py
+++ b/html2manual/menu_parser/__init__.py
@@ -1,0 +1,46 @@
+"""Menu parsing plugins for html2manual."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, List, Protocol, cast
+
+from importlib import metadata
+from importlib.metadata import EntryPoint
+
+SectionMapping = Dict[str, List[Path]]
+
+
+class MenuParser(Protocol):
+    """Protocol describing a menu parser plugin."""
+
+    name: str
+
+    def parse(self, menu_path: Path, contents_dir: Path) -> SectionMapping:
+        """Parse the provided menu file and return a mapping of sections to HTML paths."""
+
+
+def _load_menu_entry_points() -> Iterable[EntryPoint]:
+    try:
+        return metadata.entry_points(group="html2manual.menu_parsers")
+    except TypeError:  # pragma: no cover - older importlib.metadata versions
+        entries = metadata.entry_points()
+        if hasattr(entries, "get"):
+            legacy_raw: object = entries.get("html2manual.menu_parsers", [])
+            legacy: Iterable[EntryPoint] = cast(Iterable[EntryPoint], legacy_raw)
+            return legacy
+        return ()
+
+
+def iter_entry_point_parsers() -> Iterable[MenuParser]:
+    """Yield menu parser plugins exposed via entry points."""
+
+    for entry_point in _load_menu_entry_points():
+        loaded = entry_point.load()
+        if isinstance(loaded, type):
+            parser: MenuParser = loaded()  # type: ignore[call-arg]
+        else:
+            parser = loaded  # type: ignore[assignment]
+        yield parser
+
+
+__all__ = ["MenuParser", "SectionMapping", "iter_entry_point_parsers"]

--- a/html2manual/menu_parser/fallback_contents.py
+++ b/html2manual/menu_parser/fallback_contents.py
@@ -1,0 +1,46 @@
+"""Fallback strategies when no explicit menu is provided."""
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from . import SectionMapping
+
+
+@dataclass
+class FallbackStrategy:
+    """Configuration for fallback grouping."""
+
+    mode: str = "single"
+
+    def group(self, files: Iterable[Path]) -> SectionMapping:
+        files = list(sorted(files))
+        if self.mode == "single":
+            return {"manual": files}
+        if self.mode == "prefix":
+            grouped: Dict[str, List[Path]] = defaultdict(list)
+            for file in files:
+                prefix = file.stem.split("_")[0]
+                grouped[prefix].append(file)
+            return dict(grouped)
+        if self.mode == "subfolder":
+            grouped = defaultdict(list)
+            for file in files:
+                key = file.parent.name or "root"
+                grouped[key].append(file)
+            return dict(grouped)
+        raise ValueError(f"Unknown fallback strategy: {self.mode}")
+
+
+def discover_html_files(input_dir: Path, pattern: str) -> List[Path]:
+    return sorted(input_dir.glob(pattern))
+
+
+def fallback_sections(input_dir: Path, pattern: str, strategy: FallbackStrategy) -> SectionMapping:
+    files = discover_html_files(input_dir, pattern)
+    return strategy.group(files)
+
+
+__all__ = ["FallbackStrategy", "fallback_sections", "discover_html_files"]

--- a/html2manual/menu_parser/mftbc_menu.py
+++ b/html2manual/menu_parser/mftbc_menu.py
@@ -1,0 +1,32 @@
+"""Parser for Mitsubishi Fuso style menu files."""
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from pathlib import Path
+from typing import List
+
+from . import SectionMapping
+
+DISPLAY_PATTERN = re.compile(r"display\('([^']+)',\s*'([^']+)',\s*'(/[^']+)'\)")
+
+
+class MFTBCMenuParser:
+    """Parse menu files with ``display('file','title','/SECTION/...')`` entries."""
+
+    name = "mftbc"
+
+    def parse(self, menu_path: Path, contents_dir: Path) -> SectionMapping:
+        text = menu_path.read_text(encoding="utf-8", errors="ignore")
+        matches = DISPLAY_PATTERN.findall(text)
+        sections: "OrderedDict[str, List[Path]]" = OrderedDict()
+        for file_name, _title, section_path in matches:
+            section_key = section_path.strip("/").split("/")[0]
+            sections.setdefault(section_key, [])
+            resolved = (contents_dir / file_name).resolve()
+            if resolved not in sections[section_key]:
+                sections[section_key].append(resolved)
+        return dict(sections)
+
+
+__all__ = ["MFTBCMenuParser", "DISPLAY_PATTERN"]

--- a/html2manual/pipeline.py
+++ b/html2manual/pipeline.py
@@ -1,0 +1,124 @@
+"""Pipeline orchestration for html2manual."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Dict, List
+
+import structlog
+
+from .config import Html2ManualConfig
+from .flatten.html_processor import HtmlProcessor
+from .menu_parser import SectionMapping, iter_entry_point_parsers
+from .menu_parser.fallback_contents import FallbackStrategy, fallback_sections
+from .menu_parser.mftbc_menu import MFTBCMenuParser
+from .render.merge import PdfMerger
+from .render.playwright import PlaywrightRenderer
+from .render.wkhtml import WkhtmlRenderer
+
+LOGGER = structlog.get_logger(__name__)
+
+
+def parse_sections(config: Html2ManualConfig) -> SectionMapping:
+    menu_path = config.input_dir / config.menu_file
+    if menu_path.exists():
+        parsers = [MFTBCMenuParser(), *iter_entry_point_parsers()]
+        for parser in parsers:
+            try:
+                sections = parser.parse(menu_path, config.input_dir)
+            except Exception as exc:  # pragma: no cover - plugin errors logged
+                LOGGER.warning("menu_parser_failed", parser=parser.name, error=str(exc))
+                continue
+            if sections:
+                LOGGER.info("menu_parser_selected", parser=parser.name, sections=len(sections))
+                return sections
+    LOGGER.info("menu_fallback", strategy=config.fallback_strategy)
+    return fallback_sections(
+        config.input_dir, config.contents_glob, FallbackStrategy(mode=config.fallback_strategy)
+    )
+
+
+def flatten_sections(config: Html2ManualConfig, sections: SectionMapping) -> Dict[str, List[Path]]:
+    processor = HtmlProcessor(
+        css_inline=config.css_inline,
+        js_inline=config.js_inline,
+        images_inline=config.images_inline,
+        overflow_fix_enable=config.overflow_fix_enable,
+        overflow_selectors=config.overflow_fix_selectors,
+    )
+    flattened_root = config.output_dir / "flattened"
+    flattened_root.mkdir(parents=True, exist_ok=True)
+    flattened: Dict[str, List[Path]] = {}
+    for section, files in sections.items():
+        section_dir = flattened_root / section
+        section_dir.mkdir(parents=True, exist_ok=True)
+        flattened_paths: List[Path] = []
+        for html_file in files:
+            if not html_file.exists():
+                LOGGER.warning("flatten_missing_file", file=str(html_file))
+                continue
+            destination = section_dir / html_file.name
+            result = processor.flatten_to_file(html_file, destination)
+            if result.warnings:
+                for warning in result.warnings:
+                    LOGGER.warning("flatten_warning", file=str(html_file), warning=warning)
+            flattened_paths.append(destination)
+        flattened[section] = flattened_paths
+    return flattened
+
+
+def render_sections(config: Html2ManualConfig, flattened: Dict[str, List[Path]]) -> Dict[str, Path]:
+    renderer = WkhtmlRenderer(
+        executable=config.wkhtmltopdf_path,
+        page_size=config.page_size,
+        margin_top=config.margin_top,
+        margin_bottom=config.margin_bottom,
+        margin_left=config.margin_left,
+        margin_right=config.margin_right,
+        zoom=config.zoom,
+        chunk_size=config.chunk_size,
+    )
+    merger = PdfMerger()
+    output_manuals: Dict[str, Path] = {}
+    manuals_dir = config.output_dir / "Manuals"
+    manuals_dir.mkdir(parents=True, exist_ok=True)
+
+    for section, files in flattened.items():
+        LOGGER.info("render_section_start", section=section, files=len(files))
+        chunk_pdfs: List[Path]
+        try:
+            chunk_pdfs = renderer.render(section, files, manuals_dir)
+        except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+            LOGGER.warning("wkhtml_render_failed", section=section, error=str(exc))
+            if not config.playwright_fallback:
+                raise
+            LOGGER.info("playwright_fallback_start", section=section)
+            fallback = PlaywrightRenderer(
+                page_size=config.page_size,
+                margin_top=config.margin_top,
+                margin_bottom=config.margin_bottom,
+                margin_left=config.margin_left,
+                margin_right=config.margin_right,
+                zoom=config.zoom,
+            )
+            chunk_pdfs = fallback.render(section, files, manuals_dir)
+        if len(chunk_pdfs) > 1:
+            merged_path = manuals_dir / f"{section}.pdf"
+            merger.merge(chunk_pdfs, merged_path)
+            output_manuals[section] = merged_path
+            for extra in chunk_pdfs:
+                extra.unlink(missing_ok=True)
+        else:
+            output_manuals[section] = chunk_pdfs[0]
+        LOGGER.info("render_section_complete", section=section, pdf=str(output_manuals[section]))
+    return output_manuals
+
+
+def build_manuals(config: Html2ManualConfig) -> Dict[str, Path]:
+    sections = parse_sections(config)
+    flattened = flatten_sections(config, sections)
+    manuals = render_sections(config, flattened)
+    return manuals
+
+
+__all__ = ["build_manuals", "parse_sections", "flatten_sections", "render_sections"]

--- a/html2manual/render/README.md
+++ b/html2manual/render/README.md
@@ -1,0 +1,4 @@
+# Render Subpackage
+
+Rendering backends used by html2manual. Includes wkhtmltopdf integration, a
+Playwright fallback, and PDF merging utilities.

--- a/html2manual/render/__init__.py
+++ b/html2manual/render/__init__.py
@@ -1,0 +1,7 @@
+"""Rendering backends for html2manual."""
+
+from .wkhtml import WkhtmlRenderer
+from .playwright import PlaywrightRenderer
+from .merge import PdfMerger
+
+__all__ = ["WkhtmlRenderer", "PlaywrightRenderer", "PdfMerger"]

--- a/html2manual/render/merge.py
+++ b/html2manual/render/merge.py
@@ -1,0 +1,25 @@
+"""PDF merging utilities."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from pypdf import PdfReader, PdfWriter
+
+
+class PdfMerger:
+    """Merge multiple PDF chunks into a single file."""
+
+    def merge(self, pdf_paths: Iterable[Path], output_path: Path) -> Path:
+        writer = PdfWriter()
+        for pdf in pdf_paths:
+            reader = PdfReader(str(pdf))
+            for page in reader.pages:
+                writer.add_page(page)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("wb") as handle:
+            writer.write(handle)
+        return output_path
+
+
+__all__ = ["PdfMerger"]

--- a/html2manual/render/playwright.py
+++ b/html2manual/render/playwright.py
@@ -1,0 +1,60 @@
+"""Playwright based rendering fallback."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Sequence
+
+
+class PlaywrightRenderer:
+    """Render HTML files to PDF using Playwright's headless Chromium."""
+
+    def __init__(
+        self,
+        *,
+        page_size: str = "A4",
+        margin_top: str = "10mm",
+        margin_bottom: str = "10mm",
+        margin_left: str = "10mm",
+        margin_right: str = "10mm",
+        zoom: float = 1.0,
+    ) -> None:
+        self.page_size = page_size
+        self.margin_top = margin_top
+        self.margin_bottom = margin_bottom
+        self.margin_left = margin_left
+        self.margin_right = margin_right
+        self.zoom = zoom
+
+    def render(self, section_name: str, html_files: Sequence[Path], output_dir: Path) -> List[Path]:
+        from playwright.sync_api import sync_playwright  # type: ignore
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        outputs: List[Path] = []
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            context = browser.new_context()
+            for index, html_file in enumerate(html_files, start=1):
+                page = context.new_page()
+                page.goto(html_file.as_uri(), wait_until="networkidle")
+                page.emulate_media(media="print")
+                output_file = output_dir / f"{section_name}_{index:02d}.pdf"
+                page.pdf(
+                    path=str(output_file),
+                    format=self.page_size,
+                    print_background=True,
+                    margin={
+                        "top": self.margin_top,
+                        "bottom": self.margin_bottom,
+                        "left": self.margin_left,
+                        "right": self.margin_right,
+                    },
+                    scale=self.zoom,
+                )
+                outputs.append(output_file)
+                page.close()
+            context.close()
+            browser.close()
+        return outputs
+
+
+__all__ = ["PlaywrightRenderer"]

--- a/html2manual/render/wkhtml.py
+++ b/html2manual/render/wkhtml.py
@@ -1,0 +1,95 @@
+"""wkhtmltopdf rendering backend."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Sequence
+
+
+class WkhtmlRenderer:
+    """Render HTML files to PDF using wkhtmltopdf with chunking support."""
+
+    def __init__(
+        self,
+        *,
+        executable: Path | None = None,
+        page_size: str = "A4",
+        margin_top: str = "10mm",
+        margin_bottom: str = "10mm",
+        margin_left: str = "10mm",
+        margin_right: str = "10mm",
+        zoom: float = 1.0,
+        chunk_size: int = 50,
+    ) -> None:
+        self.executable = executable
+        self.page_size = page_size
+        self.margin_top = margin_top
+        self.margin_bottom = margin_bottom
+        self.margin_left = margin_left
+        self.margin_right = margin_right
+        self.zoom = zoom
+        self.chunk_size = max(1, chunk_size)
+
+    @property
+    def command(self) -> str:
+        if self.executable:
+            return str(self.executable)
+        resolved = shutil.which("wkhtmltopdf")
+        if not resolved:
+            raise FileNotFoundError("wkhtmltopdf executable not found on PATH")
+        return resolved
+
+    def _build_args(self, inputs: Sequence[Path], output: Path) -> List[str]:
+        args = [
+            self.command,
+            "--enable-local-file-access",
+            "--print-media-type",
+            "--page-size",
+            self.page_size,
+            "--margin-top",
+            self.margin_top,
+            "--margin-bottom",
+            self.margin_bottom,
+            "--margin-left",
+            self.margin_left,
+            "--margin-right",
+            self.margin_right,
+            "--zoom",
+            str(self.zoom),
+        ]
+        args.extend(str(path) for path in inputs)
+        args.append(str(output))
+        return args
+
+    def _run(self, args: Sequence[str]) -> None:
+        subprocess.run(args, check=True)
+
+    def _chunk(self, files: Sequence[Path]) -> List[List[Path]]:
+        if len(files) <= self.chunk_size:
+            return [list(files)]
+        chunks: List[List[Path]] = []
+        current: List[Path] = []
+        for html in files:
+            current.append(html)
+            if len(current) >= self.chunk_size:
+                chunks.append(current)
+                current = []
+        if current:
+            chunks.append(current)
+        return chunks
+
+    def render(self, section_name: str, html_files: Sequence[Path], output_dir: Path) -> List[Path]:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        chunks = self._chunk(html_files)
+        outputs: List[Path] = []
+        for index, chunk in enumerate(chunks, start=1):
+            suffix = f"_{index:02d}" if len(chunks) > 1 else ""
+            output_file = output_dir / f"{section_name}{suffix}.pdf"
+            args = self._build_args(chunk, output_file)
+            self._run(args)
+            outputs.append(output_file)
+        return outputs
+
+
+__all__ = ["WkhtmlRenderer"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import nox
+
+nox.options.sessions = ["lint", "typecheck", "tests"]
+
+
+@nox.session()
+def lint(session: nox.Session) -> None:
+    session.install(".[dev]")
+    session.run("ruff", "check", ".")
+    session.run("black", "--check", ".")
+
+
+@nox.session()
+def typecheck(session: nox.Session) -> None:
+    session.install(".[dev]")
+    session.run("mypy", ".")
+
+
+@nox.session()
+def tests(session: nox.Session) -> None:
+    session.install(".[dev]")
+    session.run("pytest")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,69 @@
+[build-system]
+requires = ["hatchling>=1.18"]
+build-backend = "hatchling.build"
+
+[project]
+name = "html2manual"
+version = "0.1.0"
+description = "Flatten HTML manuals and render sectioned PDFs"
+authors = [{name = "html2manual maintainers"}]
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+dependencies = [
+  "pydantic>=2.0",
+  "typer>=0.9",
+  "structlog>=23.1",
+  "charset-normalizer>=3.0",
+  "beautifulsoup4>=4.12",
+  "pypdf>=3.9",
+  "PyYAML>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.4",
+  "pytest-cov>=4.1",
+  "mypy>=1.6",
+  "ruff>=0.1.8",
+  "black>=23.12",
+  "nox>=2023.4.22",
+  "types-PyYAML",
+]
+playwright = [
+  "playwright>=1.39",
+]
+
+[project.scripts]
+html2manual = "html2manual.cli:app"
+
+[project.entry-points."html2manual.menu_parsers"]
+default = "html2manual.menu_parser.mftbc_menu:MFTBCMenuParser"
+
+[tool.black]
+line-length = 100
+
+[tool.ruff]
+line-length = 100
+select = ["E", "F", "I", "B"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-q"
+
+[tool.mypy]
+python_version = "3.11"
+packages = ["html2manual"]
+ignore_missing_imports = true
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "html2manual",
+  "examples",
+  "tests",
+  "README.md",
+  "Makefile",
+  "noxfile.py",
+  "Dockerfile",
+  "html2manual.spec",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture()
+def assets_dir(tmp_path: Path) -> Path:
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    return assets
+
+
+@pytest.fixture()
+def sample_html(tmp_path: Path, assets_dir: Path) -> Path:
+    css = assets_dir / "style.css"
+    css.write_text(".box { background: url('image.png'); }", encoding="utf-8")
+    js = assets_dir / "script.js"
+    js.write_text("console.log('hi');", encoding="utf-8")
+    img = assets_dir / "image.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 10)
+    html = tmp_path / "page.html"
+    html.write_text(
+        """
+        <html>
+        <head>
+            <link rel="stylesheet" href="assets/style.css">
+        </head>
+        <body>
+            <div class="box" style="overflow:auto;height:100px;background:url('assets/image.png');">
+                <img src="assets/image.png" />
+            </div>
+            <script src="assets/script.js"></script>
+        </body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+    return html

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from html2manual.audit import audit_html, audit_manual
+
+
+def test_audit_flags_scrollable_container(sample_html: Path) -> None:
+    issues = audit_html(sample_html)
+    assert any("Scrollable container" in issue.issue for issue in issues)
+
+
+def test_audit_flags_missing_assets(tmp_path: Path) -> None:
+    html = tmp_path / "missing.html"
+    html.write_text(
+        """
+        <html>
+            <body>
+                <img src="missing.png" />
+                <a href="missing_page.html">Broken</a>
+            </body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+    issues = audit_html(html)
+    descriptions = {issue.issue for issue in issues}
+    assert any(issue.startswith("Missing asset") for issue in descriptions)
+    assert any(issue.startswith("Broken link") for issue in descriptions)
+
+
+def test_audit_manual_collects_all(tmp_path: Path) -> None:
+    html1 = tmp_path / "a.html"
+    html1.write_text("<html><body><div style='overflow:auto'></div></body></html>", encoding="utf-8")
+    html2 = tmp_path / "b.html"
+    html2.write_text("<html><body><img src='missing.png'/></body></html>", encoding="utf-8")
+    issues = audit_manual(tmp_path, "*.html")
+    assert len(issues) >= 2
+    assert {issue.file for issue in issues} == {html1, html2}

--- a/tests/test_inlining.py
+++ b/tests/test_inlining.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+from html2manual.flatten.css_inliner import embed_css_urls, inline_css
+from html2manual.flatten.image_inliner import inline_images
+from html2manual.flatten.js_inliner import inline_js
+from html2manual.flatten.overflow_fix import apply_overflow_fix
+from html2manual.flatten.html_processor import HtmlProcessor
+
+
+def test_css_inliner_inlines_link_styles(sample_html: Path) -> None:
+    html = sample_html.read_text(encoding="utf-8")
+    inlined = inline_css(html, sample_html)
+    assert "<link" not in inlined
+    assert "background: url('data:" in inlined
+
+
+def test_js_inliner_inlines_external_scripts(sample_html: Path) -> None:
+    html = sample_html.read_text(encoding="utf-8")
+    inlined = inline_js(html, sample_html)
+    assert "script.js" not in inlined
+    assert "console.log('hi');" in inlined
+
+
+def test_image_inliner_replaces_img_sources(sample_html: Path) -> None:
+    html = sample_html.read_text(encoding="utf-8")
+    inlined = inline_images(html, sample_html)
+    assert "src=\"data:" in inlined
+
+
+def test_background_image_embedding(assets_dir: Path, sample_html: Path) -> None:
+    css = (assets_dir / "style.css").read_text(encoding="utf-8")
+    embedded = embed_css_urls(css, assets_dir)
+    assert "data:image/png;base64" in embedded
+
+
+def test_overflow_fix_inline_and_style_block(sample_html: Path) -> None:
+    html = sample_html.read_text(encoding="utf-8")
+    fixed = apply_overflow_fix(html, [".box"])
+    assert "overflow:auto" not in fixed
+    assert "height: auto" in fixed
+
+
+def test_overflow_fix_style_tag() -> None:
+    html = """
+    <html>
+    <head><style>.box { overflow: scroll; height: 120px; }</style></head>
+    <body></body>
+    </html>
+    """
+    fixed = apply_overflow_fix(html, [".box"])
+    assert "overflow: visible" in fixed
+    assert "height: auto" in fixed
+
+
+def test_html_processor_runs_full_pipeline(sample_html: Path) -> None:
+    processor = HtmlProcessor()
+    result = processor.flatten(sample_html)
+    assert "data:image/png" in result.html
+    assert "console.log('hi');" in result.html

--- a/tests/test_menu_parser.py
+++ b/tests/test_menu_parser.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from html2manual.menu_parser.fallback_contents import FallbackStrategy, fallback_sections
+from html2manual.menu_parser.mftbc_menu import MFTBCMenuParser
+
+
+def test_menu_parser_parses_display_entries(tmp_path: Path) -> None:
+    menu = tmp_path / "menu.html"
+    contents = tmp_path / "Contents"
+    contents.mkdir()
+    (contents / "page1.html").write_text("<html></html>", encoding="utf-8")
+    (contents / "page2.html").write_text("<html></html>", encoding="utf-8")
+    menu.write_text(
+        "display('Contents/page1.html','Page 1','/SECTION1/Intro');\n"
+        "display('Contents/page2.html','Page 2','/SECTION1/Intro');",
+        encoding="utf-8",
+    )
+    parser = MFTBCMenuParser()
+    sections = parser.parse(menu, tmp_path)
+    assert list(sections.keys()) == ["SECTION1"]
+    assert [path.name for path in sections["SECTION1"]] == ["page1.html", "page2.html"]
+
+
+def test_fallback_prefix_strategy(tmp_path: Path) -> None:
+    contents = tmp_path / "docs"
+    contents.mkdir()
+    for name in ["alpha_intro.html", "alpha_details.html", "beta_start.html"]:
+        (contents / name).write_text("<html></html>", encoding="utf-8")
+    sections = fallback_sections(contents, "*.html", FallbackStrategy(mode="prefix"))
+    assert set(sections.keys()) == {"alpha", "beta"}
+    assert [path.name for path in sections["alpha"]] == ["alpha_details.html", "alpha_intro.html"]

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pypdf import PdfWriter
+
+from html2manual.render.merge import PdfMerger
+from html2manual.render.wkhtml import WkhtmlRenderer
+
+
+def _write_dummy_pdf(path: Path) -> None:
+    writer = PdfWriter()
+    writer.add_blank_page(width=10, height=10)
+    with path.open("wb") as handle:
+        writer.write(handle)
+
+
+def test_wkhtml_renderer_chunks(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    renderer = WkhtmlRenderer(chunk_size=2)
+    renderer.executable = Path("/usr/bin/wkhtmltopdf")
+    html_files = []
+    for idx in range(5):
+        html = tmp_path / f"file{idx}.html"
+        html.write_text("<html></html>", encoding="utf-8")
+        html_files.append(html)
+
+    def fake_run(args: list[str]) -> None:
+        _write_dummy_pdf(Path(args[-1]))
+
+    monkeypatch.setattr(renderer, "_run", fake_run)
+    outputs = renderer.render("section", html_files, tmp_path)
+    assert len(outputs) == 3
+    for pdf in outputs:
+        assert pdf.exists()
+
+
+def test_pdf_merger(tmp_path: Path) -> None:
+    pdf1 = tmp_path / "chunk1.pdf"
+    pdf2 = tmp_path / "chunk2.pdf"
+    _write_dummy_pdf(pdf1)
+    _write_dummy_pdf(pdf2)
+    merger = PdfMerger()
+    merged = merger.merge([pdf1, pdf2], tmp_path / "merged.pdf")
+    assert merged.exists()
+    assert merged.read_bytes().startswith(b"%PDF")


### PR DESCRIPTION
## Summary
- replace sample manual styling to avoid referencing PNG assets
- remove binary image placeholders from the sample manual assets directory

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db7aa6084c8324b171aa30b8edb88b